### PR TITLE
Fix shebang lines and make them more consistent.

### DIFF
--- a/LAI
+++ b/LAI
@@ -1,4 +1,5 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use File::Basename;
 ##This script is to estimate the mean LTR sequence identity in the genome

--- a/LTR_retriever
+++ b/LTR_retriever
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use File::Basename;
 

--- a/bin/Age_est.pl
+++ b/bin/Age_est.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use File::Basename;
 

--- a/bin/LAI_calc3.pl
+++ b/bin/LAI_calc3.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #Description: This is the core script to calculate the LTR Assembly Index

--- a/bin/LTR.identifier.debug.pl
+++ b/bin/LTR.identifier.debug.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use threads;
 use Thread::Queue;

--- a/bin/LTR.identifier.pl
+++ b/bin/LTR.identifier.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use threads;
 use Thread::Queue;

--- a/bin/LTR_sum.pl
+++ b/bin/LTR_sum.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #Description: This is the script to calculate the LTR-RT distribution of different superfamilies

--- a/bin/PacBio_processor.pl
+++ b/bin/PacBio_processor.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 #covert PacBio fastq file into fasta file with simple filtering options
 #Usage: perl PacBio_processor.pl PacBio.fastq > PacBio.fasta
 #06/30/2016 Shujun Ou (oushujun@msu.edu)
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my $minLength=500;

--- a/bin/Six-frame_translate.pl
+++ b/bin/Six-frame_translate.pl
@@ -1,7 +1,9 @@
+#!/usr/bin/env perl
+
 ##Shujun Ou
 ##Usage: perl Six-frame_translate.pl sequence.nt.fa > sequence.aa.fa
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my %codon2aa = qw(

--- a/bin/align_flanking.pl
+++ b/bin/align_flanking.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $usage="

--- a/bin/annotate_TE.pl
+++ b/bin/annotate_TE.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 ##Description: Identify TE type (LTR or not LTR), LTR family (copia or gypsy), and strand of the input hmmsearch table
 ##		hmm profile categories were made based on the rice TE library "rice6.8.liban"
 ##Usage:       perl annotate_TE.pl hmmsearch.tbl > TE.family-strand.tbl
@@ -7,7 +9,7 @@
 ##Versions:    v1.0	06/16/2016
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my %notLTR=qw(PF10551.6 notLTR PF13966.3 notLTR PF04434.14 notLTR PF03108.12 notLTR PF13359.3 notLTR PF00872.15 notLTR PF05699.11 notLTR PF13963.3 notLTR PF04827.11 notLTR PF05970.11 notLTR PF03101.12 notLTR PF13960.3 notLTR PF02992.11 notLTR PF14214.3 notLTR PF12776.4 notLTR PF13952.3 notLTR PF03372.20 notLTR PF14372.3 notLTR PF14303.3 notLTR PF13604.3 notLTR PF01498.15 notLTR PF01609.18 notLTR PF13837.3 notLTR PF13538.3 notLTR PF02892.12 notLTR PF13384.3 notLTR PF06839.9 notLTR PF03004.11 notLTR PF04937.12 notLTR PF13191.3 notLTR PF02902.16 notLTR PF12728.4 notLTR PF14291.3 notLTR PF14529.3 notLTR PF10446.6 notLTR PF14111.3 notLTR PF13873.3 notLTR PF13245.3 notLTR PF04147.9 notLTR PF13542.3 notLTR PF05285.9 notLTR PF00376.20 notLTR PF00249.28 notLTR PF00646.30 notLTR PF12116.5 notLTR PF09322.7 notLTR PF00437.17 notLTR PF13401.3 notLTR PF06869.9 notLTR PF13857.3 notLTR PF04967.9 notLTR PF00564.21 notLTR PF13412.3 notLTR PF12796.4 notLTR PF06072.8 notLTR);

--- a/bin/annotate_gff.pl
+++ b/bin/annotate_gff.pl
@@ -1,8 +1,10 @@
+#!/usr/bin/env perl
+
 ##To annotate the gff file with information from the library
 ##Usage: perl annotate_gff.pl lib.fa gff > anno.gff
 ##Shujun Ou (oushujun@msu.edu)
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my $usage="perl annotate_gff.pl lib.fa gff > anno.gff\n";

--- a/bin/annotate_lib.pl
+++ b/bin/annotate_lib.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 ##To annotate library with family and direction information
 ##Usage: perl annotate_lib.pl $index.scn.adj $index.LTRlib.fa
 ##Shujun Ou (oushujun@msu.edu) 06/23/2016
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 open List, "<$ARGV[0]" or die "ERROR: $!";

--- a/bin/call_seq_by_list.pl
+++ b/bin/call_seq_by_list.pl
@@ -1,4 +1,5 @@
-#!uer/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $usage="\tUsage: perl call_seq_by_list.pl MSU_format_list database(optional, C[custom]) range(optional, itself[default]/up_[int]/down_[int])

--- a/bin/cleanOutput.pl
+++ b/bin/cleanOutput.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my ($index, $LINE, $DNA, $PlantP)=('', '', '', '');

--- a/bin/cleanPro.pl
+++ b/bin/cleanPro.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 #Usage: perl cleanPro.pl fastafile blastxout(fmt6) -o [1|0] -l [int] -c [0,1] > sequence_name_out
 #Optional parameters:
 #-o [1|0] output option, default 1, to output the entries with protein hits, 0 for protein-free hits
@@ -8,7 +10,7 @@
 #Version: v1.0 12/17/2014
 
 
-#!usr/bin/perl -w
+use warnings;
 use strict;
 
 ##filters for the sequence alignment

--- a/bin/cleanup.pl
+++ b/bin/cleanup.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use File::Basename;
 

--- a/bin/cleanup_nestedIN.pl
+++ b/bin/cleanup_nestedIN.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 #Shujun Ou (shujun.ou.1@gmail.com) 03/26/2019
 

--- a/bin/combine_overlap.pl
+++ b/bin/combine_overlap.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #modified from http://blog.sina.com.cn/s/blog_4ba035220100tkpl.html

--- a/bin/convert_MGEScan.pl
+++ b/bin/convert_MGEScan.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 #convert MGEScan-ltr candidate list to LTR_retriever input format
 #Usage: perl convert.pl genome.ltrpos > genome.MGEScan.scn
 #Author: Shujun OU (oushujun@msu.edu) 08/13/2016
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 print "#this summary file is created from MGEScan-ltr candidate list by convert_MGEScan.pl (Author: Shujun Ou, email: oushujun\@msu.edu 08/13/2016)

--- a/bin/convert_MGEScan3.0.pl
+++ b/bin/convert_MGEScan3.0.pl
@@ -1,10 +1,12 @@
+#!/usr/bin/env perl
+
 #convert MGEScan 3.0.0 LTR candidates to LTR_retriever input format
 #Usage: perl convert_MGEScan3.0.pl 
 #convert.pl genome.ltrpos > genome.MGEScan.scn
 #Author: Shujun Ou (shujun.ou.1@gmail.com) 04/19/2019
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 print "#this summary file is created from MGEScan 3.0.0 LTR candidate list by convert_MGEScan3.0.pl (Author: Shujun Ou, email: shujun.ou.1\@gmail.com 04/19/2019)

--- a/bin/convert_ltr_finder.pl
+++ b/bin/convert_ltr_finder.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 #convert LTR_finder screen output to LTR_retriever input format
 #Usage: perl convert.pl LTR_finder_scn > out.scn
 #Author:Shujun OU (oushujun@msu.edu) 03/07/2015
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 print "#this summary file is created from LTR_finder screen output by convert_ltr_finder.pl (Author: Shujun Ou, email: oushujun\@msu.edu 2/14/2015)

--- a/bin/convert_ltr_finder2.pl
+++ b/bin/convert_ltr_finder2.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 #convert LTR_FINDER -w 2 format to LTRharvest format
 #Shujun Ou (shujun.ou.1@gmail.com) 11/13/2019

--- a/bin/convert_ltr_struc.pl
+++ b/bin/convert_ltr_struc.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $usage="\n\tperl convert_ltr_struc.pl log.txt output_path/

--- a/bin/convert_ltrdetector.pl
+++ b/bin/convert_ltrdetector.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 #convert LtrDetector default output to LTR_retriever input format
 #Usage: perl convert.pl LtrDetector.bed.scn > out.scn
 #Author:Shujun OU (shujun.ou.1@gmail.com) 04/14/2019
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my $usage = "\n\tperl convert.pl genome.fasta LtrDetector.bed.scn > out.scn\n\n";

--- a/bin/count_base.pl
+++ b/bin/count_base.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $seperate=0;

--- a/bin/count_fam_size.pl
+++ b/bin/count_fam_size.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #Count the size of each LTR family. A family is determined by the LTR region.

--- a/bin/fam_coverage.pl
+++ b/bin/fam_coverage.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $usage = "famcoverage.pl TE_lib RM_output genome_size_bp > TE_fam.size.list\n";

--- a/bin/fam_summary.pl
+++ b/bin/fam_summary.pl
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 $usage = "fam_summary.pl TE_fam.size.list genome_size_bp > TE_fam.sum.txt\n";
 

--- a/bin/fasta-reformat.pl
+++ b/bin/fasta-reformat.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 #contributed by Ning Jiang (jiangn@msu.edu)
 

--- a/bin/get_range.pl
+++ b/bin/get_range.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $usage="to out put some information from the ltrharvest_screen.scn/ltrdigest_tabout.csv/RepeatMasker.out file

--- a/bin/intact_finder_coarse.pl
+++ b/bin/intact_finder_coarse.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #Indentify intact LTRs in RM out files

--- a/bin/make_gff3.pl
+++ b/bin/make_gff3.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 ##Generate gff3 file from pass list of LTR_retriever
 ##Usage: perl make_gff3.pl genome.fa LTR.pass.list
 ##Author: Shujun Ou (oushujun@msu.edu), Department of Horticulture, Michigan State University
@@ -7,7 +9,7 @@
 
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 open FA, "<$ARGV[0]" or die "ERROR: $!";

--- a/bin/make_gff3_with_RMout.pl
+++ b/bin/make_gff3_with_RMout.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 ##Generate gff3 file from RepeatMasker .out file of LTR_retriever
 ##Usage: perl make_gff3.pl genome.fa.out
 ##Author: Shujun Ou (oushujun@msu.edu), Department of Horticulture, Michigan State University
 ##Version: 1.0 01-27-2018
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my $date=`date -u`;

--- a/bin/make_lib.pl
+++ b/bin/make_lib.pl
@@ -1,9 +1,11 @@
+#!/usr/bin/env perl
+
 #Shujun Ou
 #usage:  perl make_lib.pl *.scn.list *.ltrTE.lib *.ltrTE.lib.clust.info 
 
 
 
-#!usr/bin/perl -w
+use warnings
 use strict;
 
 open List, "<$ARGV[0]" or die "ERROR: $!";

--- a/bin/output_by_list.pl
+++ b/bin/output_by_list.pl
@@ -1,8 +1,9 @@
+#!/usr/bin/env perl
+
 ##Shujun Ou
 ##usage: $ perl output_by_list.pl target_file list_file > outfile
 
-
-#!usr/bin/perl -w
+use warnings;
 use strict;
 
 my $usage="\n#usage: \$ perl output_by_list.pl DB_index_pos database LS_index_pos LIST [Exclusive]* [MSU_format] [FASTA_format] [version]> outfile

--- a/bin/purger.pl
+++ b/bin/purger.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 use File::Basename;
 

--- a/bin/run_MGEScan.pl
+++ b/bin/run_MGEScan.pl
@@ -1,10 +1,12 @@
+#!/usr/bin/env perl
+
 #To run MGEScan-ltr on genomes containing more than one sequence/scaffolds
 #Usage: perl run_MGEScan.pl genome
 #Author: Shujun Ou (oushujun@msu.edu)	08/14/2016
 
 
 
-#!/usr/bin/env perl -w
+use warnings;
 use strict;
 
 my $genome=$ARGV[0];

--- a/bin/simulate_mutation.pl
+++ b/bin/simulate_mutation.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 my $mut_rate="0.02"; #%2 (default) of the genome will be mutated

--- a/bin/solo_finder.pl
+++ b/bin/solo_finder.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #Indentify solo LTRs in RM out files

--- a/bin/solo_intact_ratio.pl
+++ b/bin/solo_intact_ratio.pl
@@ -1,4 +1,5 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
+use warnings;
 use strict;
 
 #compute solo-intact LTR ratio for given lists


### PR DESCRIPTION
On linux (I am not sure about macOS), `#!/usr/bin/env perl -w` attempts to run a program literally named `perl -w` which does not exist. Shebang lines are now:

* Moved to the very first line of the file, where they are guaranteed to be found by the shell
* Always `#!/usr/bin/env perl`

Scripts that had `perl -w` now have a `use warnings;` line.

---

This should only really be necessary for scripts that might be invoked from other programs i.e. `LAI` and `LTR_Retriever`, but this change can benefit anyone who might try to reuse or work with the scripts in `bin/`.