### PR TITLE
add $genome permission check

### DIFF
--- a/LTR_retriever
+++ b/LTR_retriever
@@ -300,6 +300,11 @@ if ($step eq "Init" and `ls $genome*|wc -l`>15){
 	`mkdir LTRretriever-pre$date; mv $genome*.out $genome*.out.gff* $genome*.LAI $genome*.LTRlib* $genome*defalse $genome*.ltrTE* $genome*.retriever.* $genome*.prelib* $genome*.pass.list* $genome*.out*size.list $genome.out.LTR.distribution.txt LTRretriever-pre$date/ 2>/dev/null`;
 }
 
+## check if genome writable
+
+if (not -w $genome and $annotation==1){
+	die "$genome is not writable, which may raise RepeatMask error\n\n";
+}
 
 ####################################################################
 ######### To retrieve high quality LTR-RTs with TGCA motif #########


### PR DESCRIPTION
Thank you for your work.
LAI did not run correctly.While running I get the following error  `$genome.tbl: No such file or directory` 
After checking I found out that it is due to the permissions of the $genome file.After runing `RepeatMasker -e ncbi -pa $threads -q -no_is -norna -nolow -div 40 -lib $genome.LTRlib.fa -cutoff 225 $genome` i got this error.
```shell
analyzing file $genome
FastaDB::_cleanIndexAndCompact() - Error could not open file ../LTR/RM_166328.TueMay32136282022/$genome: Permission denied
 at /miniconda3/envs/lai/bin/RepeatMasker line 739.
```
and after `chmod +w $genome` , everything runs correctly

I add two line to check if $genome is writable. 

